### PR TITLE
fix(perf): paginate OpenAI summarization to avoid 524 on large bug sets

### DIFF
--- a/snazzybot/functions/api/status.ts
+++ b/snazzybot/functions/api/status.ts
@@ -3,6 +3,8 @@ import {
   generateStatus,
   discoverCandidates,
   qualifyHistoryPage,
+  summarizeBugPage,
+  assembleSummary,
 } from "../../src/core";
 import {
   checkRateLimit,
@@ -26,7 +28,20 @@ const MIN_DAYS = 1;
 const MAX_DAYS = 365;
 const MIN_PAGE_SIZE = 1;
 const MAX_PAGE_SIZE = 1000;
-const VALID_MODES = ["discover", "page", "finalize", "oneshot"] as const;
+const VALID_MODES = [
+  "discover",
+  "page",
+  "summarize",
+  "assemble",
+  "finalize",
+  "oneshot",
+] as const;
+
+// Bound the assemble request body: accumulated fragments are markdown blobs and
+// assessments are small objects, but cap them so a malformed client can't post
+// an unbounded payload.
+const MAX_SUMMARY_FRAGMENTS = 100;
+const MAX_FRAGMENT_LENGTH = 20_000;
 const VALID_FORMATS = ["md", "html"] as const;
 const VALID_VOICES = ["normal", "pirate", "snazzy-robot"] as const;
 const VALID_AUDIENCES = ["technical", "product", "leadership"] as const;
@@ -120,6 +135,8 @@ const summarizeRequest = (body: Record<string, unknown>) => {
     assignees: arrLen(body.assignees),
     githubRepos: arrLen(body.githubRepos),
     ids: arrLen(body.ids),
+    summaryFragments: arrLen(body.summaryFragments),
+    assessments: arrLen(body.assessments),
     includePatchContext: body.includePatchContext,
     includeGithubActivity: body.includeGithubActivity,
     debug: body.debug,
@@ -201,6 +218,33 @@ const validateInput = (body: Record<string, unknown>): string | undefined => {
       pageSizeNum > MAX_PAGE_SIZE
     ) {
       return `pageSize must be between ${MIN_PAGE_SIZE} and ${MAX_PAGE_SIZE}`;
+    }
+  }
+
+  // Validate summarize/assemble payloads
+  const { summaryFragments, assessments } = body;
+  if (summaryFragments !== undefined) {
+    if (!Array.isArray(summaryFragments)) {
+      return "summaryFragments must be an array";
+    }
+    if (summaryFragments.length > MAX_SUMMARY_FRAGMENTS) {
+      return `summaryFragments array exceeds maximum length of ${MAX_SUMMARY_FRAGMENTS}`;
+    }
+    for (const fragment of summaryFragments) {
+      if (typeof fragment !== "string") {
+        return "summaryFragments must contain only strings";
+      }
+      if (fragment.length > MAX_FRAGMENT_LENGTH) {
+        return `summaryFragments string exceeds maximum length of ${MAX_FRAGMENT_LENGTH} characters`;
+      }
+    }
+  }
+  if (assessments !== undefined) {
+    if (!Array.isArray(assessments)) {
+      return "assessments must be an array";
+    }
+    if (assessments.length > MAX_ARRAY_LENGTH * 5) {
+      return `assessments array exceeds maximum length of ${MAX_ARRAY_LENGTH * 5}`;
     }
   }
 
@@ -352,6 +396,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     pageSize = 35,
     // only for finalize
     ids = [],
+    // only for summarize/assemble
+    summaryFragments = [],
+    assessments = [],
+    trimmedCount = 0,
+    candidatesTotal,
   } = body;
 
   const url = new URL(request.url);
@@ -473,6 +522,102 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             }),
           },
         );
+      } catch (error: unknown) {
+        const safeError = createSafeErrorResponse(
+          error,
+          "status-api",
+          requestSummary,
+        );
+        return new Response(
+          JSON.stringify({
+            error: safeError.message,
+            errorId: safeError.errorId,
+            logs,
+          }),
+          {
+            status: 500,
+            headers: withSecurityHeaders({
+              "content-type": "application/json; charset=utf-8",
+              "cache-control": "no-store",
+            }),
+          },
+        );
+      }
+    }
+    if (mode === "summarize") {
+      const { hooks: collectingHooks, logs } = makeCollectingHooks();
+      try {
+        const { summaryFragment, assessments, nextCursor, total, githubStats } =
+          await summarizeBugPage(
+            params,
+            envConfig,
+            ids as number[],
+            Number(cursor) || 0,
+            Number(pageSize) || 8,
+            collectingHooks,
+            !!debug,
+          );
+        return new Response(
+          JSON.stringify({
+            summaryFragment,
+            assessments,
+            nextCursor,
+            total,
+            githubStats,
+            logs,
+          }),
+          {
+            status: 200,
+            headers: withSecurityHeaders({
+              "content-type": "application/json; charset=utf-8",
+              "cache-control": "no-store",
+            }),
+          },
+        );
+      } catch (error: unknown) {
+        const safeError = createSafeErrorResponse(
+          error,
+          "status-api",
+          requestSummary,
+        );
+        return new Response(
+          JSON.stringify({
+            error: safeError.message,
+            errorId: safeError.errorId,
+            logs,
+          }),
+          {
+            status: 500,
+            headers: withSecurityHeaders({
+              "content-type": "application/json; charset=utf-8",
+              "cache-control": "no-store",
+            }),
+          },
+        );
+      }
+    }
+    if (mode === "assemble") {
+      // assembleSummary is pure formatting and emits no hook events, but we
+      // still return a logs[] array for response-shape parity with the other
+      // non-streaming modes.
+      const { logs } = makeCollectingHooks();
+      try {
+        const { output, html, stats } = assembleSummary(
+          params,
+          envConfig,
+          ids as number[],
+          summaryFragments as string[],
+          assessments as Parameters<typeof assembleSummary>[4],
+          Number(trimmedCount) || 0,
+          candidatesTotal === undefined ? undefined : Number(candidatesTotal),
+        );
+        return new Response(JSON.stringify({ output, html, stats, logs }), {
+          status: 200,
+          headers: withSecurityHeaders({
+            "content-type": "application/json; charset=utf-8",
+            "cache-control": "no-store",
+          }),
+        });
       } catch (error: unknown) {
         const safeError = createSafeErrorResponse(
           error,

--- a/snazzybot/public/app.js
+++ b/snazzybot/public/app.js
@@ -892,40 +892,74 @@ async function runSnazzyPaged(body) {
     completePhase("histories");
     log("info", `Bugzilla Qualified (history): ${qualified.size}`);
 
-    // 3) Gather patch context
+    // 3) Summarize qualified bugs in bounded pages, then assemble.
     const qualifiedIds = [...qualified];
     const includePatchContext = body.includePatchContext !== false;
     if (includePatchContext) {
       spin.textContent = "⏳ Preparing patch context…";
       ensurePhase("patch-context", "patch-context");
-      if (qualifiedIds.length > 0) {
-        setPhasePct("patch-context", 0, qualifiedIds.length);
-        setPhaseText(
-          "patch-context",
-          `patch-context: 0/${qualifiedIds.length}`,
-        );
-      } else {
-        setPhaseIndeterminate("patch-context");
-      }
+      setPhaseIndeterminate("patch-context");
+    }
+
+    // Each summarize request handles a bounded slice (bug details + patch
+    // context + OpenAI for just that slice), keeping every request well under
+    // Cloudflare's ~100s edge budget and the Free-tier 50-subrequest cap. The
+    // client loops over all qualified bugs, so nothing is silently dropped no
+    // matter how many a user has fixed.
+    const summaryFragments = [];
+    const allAssessments = [];
+    const summarizeStep = 8;
+    ensurePhase("openai", "openai");
+    if (qualifiedIds.length > 0) {
+      setPhasePct("openai", 0, qualifiedIds.length);
+      setPhaseText("openai", `openai: 0/${qualifiedIds.length}`);
     } else {
-      spin.textContent = "⏳ Summarizing…";
-      ensurePhase("openai", "openai");
       setPhaseIndeterminate("openai");
     }
-    // 4) Finalize (OpenAI + output)
-    const final = await postStatusJSON({
-      ...body,
-      mode: "finalize",
-      ids: qualifiedIds,
-    });
-    logStats(final.stats);
+    let summarizeCursor = 0;
+    while (
+      summarizeCursor != undefined &&
+      summarizeCursor < qualifiedIds.length
+    ) {
+      const end = Math.min(
+        summarizeCursor + summarizeStep,
+        qualifiedIds.length,
+      );
+      spin.textContent = `⏳ Summarizing ${summarizeCursor + 1}-${end} of ${qualifiedIds.length}`;
+      const chunk = await postStatusJSON({
+        ...body,
+        mode: "summarize",
+        ids: qualifiedIds,
+        cursor: summarizeCursor,
+        pageSize: summarizeStep,
+      });
+      if (typeof chunk.summaryFragment === "string" && chunk.summaryFragment) {
+        summaryFragments.push(chunk.summaryFragment);
+      }
+      for (const assessment of chunk.assessments || []) {
+        allAssessments.push(assessment);
+      }
+      setPhasePct("openai", end, qualifiedIds.length);
+      setPhaseText("openai", `openai: ${end}/${qualifiedIds.length}`);
+      summarizeCursor = chunk.nextCursor;
+    }
     if (includePatchContext) {
       completePhase("patch-context");
       setPhaseText("patch-context", "patch-context: done");
-      spin.textContent = "⏳ Summarizing…";
     }
-    ensurePhase("openai", "openai");
-    setPhaseIndeterminate("openai");
+
+    // 4) Assemble the final report (formatting only — issues no upstream calls).
+    spin.textContent = "⏳ Finishing…";
+    const final = await postStatusJSON({
+      ...body,
+      mode: "assemble",
+      ids: qualifiedIds,
+      summaryFragments,
+      assessments: allAssessments,
+      trimmedCount: 0,
+      candidatesTotal: total,
+    });
+    logStats(final.stats);
     lastMarkdown = typeof final.output === "string" ? final.output.trim() : "";
     if (typeof final.html === "string" && final.html) {
       lastHTML = final.html;

--- a/snazzybot/src/core.ts
+++ b/snazzybot/src/core.ts
@@ -2,6 +2,8 @@ export {
   generateStatus,
   discoverCandidates,
   qualifyHistoryPage,
+  summarizeBugPage,
+  assembleSummary,
   buildBuglistURL,
   isRestricted,
 } from "./status/service.ts";

--- a/snazzybot/src/status/context.ts
+++ b/snazzybot/src/status/context.ts
@@ -15,7 +15,11 @@ import type {
 import type { GitHubActivity, GitHubContributor } from "./githubTypes.ts";
 import type { JiraIssue, JiraIssueHistory } from "./jiraTypes.ts";
 
-export const MAX_BUGS_FOR_OPENAI = 60;
+// Guardrail for the legacy single-request paths (oneshot/finalize/streaming/CLI)
+// that run the whole pipeline in one request. The paginated web flow
+// (summarizeBugPage) bounds each request itself and is NOT subject to this cap,
+// so it summarizes every qualified bug.
+export const MAX_BUGS_FOR_OPENAI = 200;
 
 export type AudienceOption = "technical" | "product" | "leadership";
 export type VoiceOption = "normal" | "pirate" | "snazzy-robot";

--- a/snazzybot/src/status/githubStage.ts
+++ b/snazzybot/src/status/githubStage.ts
@@ -1,0 +1,158 @@
+import { GitHubClient } from "./githubClient.ts";
+import { filterGithubActivity } from "./qualification.ts";
+import type { GitHubActivity, GitHubContributor } from "./githubTypes.ts";
+import type { DebugLog, EnvLike, ProgressHooks } from "./types.ts";
+
+export type GithubContributorResult = {
+  activity: GitHubActivity[];
+  contributors: Map<string, GitHubContributor>;
+  stats?: {
+    candidates: { commits: number; prs: number };
+    qualified: { commits: number; prs: number };
+  };
+};
+
+const emptyResult = (): GithubContributorResult => ({
+  activity: [],
+  contributors: new Map(),
+});
+
+/**
+ * Fetch GitHub repo activity, qualify it against the time window, and build the
+ * per-contributor map the summarizer credits.
+ *
+ * Extracted from fetchGithubActivityStep so both the recipe step and the
+ * paginated `summarizeBugPage` flow can fetch GitHub activity exactly once
+ * (the paginated flow only calls this for the first chunk).
+ */
+export async function collectGithubContributors(
+  env: EnvLike,
+  options: {
+    githubRepos: string[];
+    emailMapping: Record<string, string>;
+    sinceISO: string;
+    includeGithubActivity: boolean;
+  },
+  hooks: ProgressHooks,
+  debugLog?: DebugLog,
+): Promise<GithubContributorResult> {
+  const { githubRepos, emailMapping, sinceISO, includeGithubActivity } =
+    options;
+
+  if (!includeGithubActivity || githubRepos.length === 0) {
+    return emptyResult();
+  }
+
+  if (!env.GITHUB_API_KEY) {
+    hooks.warn?.("GitHub API key not provided; skipping GitHub activity");
+    return emptyResult();
+  }
+
+  const client = new GitHubClient(env);
+  const activities = [];
+
+  for (const repo of githubRepos) {
+    try {
+      hooks.info?.(`Fetching GitHub activity for ${repo}`);
+      const activity = await client.getRepoActivity(repo, sinceISO);
+      activities.push(activity);
+    } catch (error) {
+      hooks.warn?.(`Failed to fetch GitHub activity for ${repo}: ${error}`);
+    }
+  }
+
+  const filteredActivities = [];
+  let droppedCommits = 0;
+  let droppedPullRequests = 0;
+  let totalCommits = 0;
+  let totalPullRequests = 0;
+
+  for (const activity of activities) {
+    totalCommits += activity.commits.length;
+    totalPullRequests += activity.pullRequests.length;
+    const filtered = filterGithubActivity(activity, sinceISO);
+    filteredActivities.push(filtered.activity);
+    droppedCommits += filtered.droppedCommits;
+    droppedPullRequests += filtered.droppedPullRequests;
+  }
+
+  hooks.info?.(
+    `GitHub Candidates: ${totalCommits} commit${
+      totalCommits === 1 ? "" : "s"
+    }, ${totalPullRequests} PR${totalPullRequests === 1 ? "" : "s"}`,
+  );
+
+  if (droppedCommits + droppedPullRequests > 0) {
+    hooks.info?.(
+      `GitHub filters removed: ${droppedCommits} commits, ${droppedPullRequests} PRs`,
+    );
+  }
+
+  hooks.info?.(
+    `GitHub Qualified (window): ${totalCommits - droppedCommits} commit${
+      totalCommits - droppedCommits === 1 ? "" : "s"
+    }, ${totalPullRequests - droppedPullRequests} PR${
+      totalPullRequests - droppedPullRequests === 1 ? "" : "s"
+    }`,
+  );
+
+  const contributors = new Map<string, GitHubContributor>();
+
+  const reverseEmailMapping = new Map<string, string>();
+  for (const [bugzillaEmail, githubUsername] of Object.entries(emailMapping)) {
+    reverseEmailMapping.set(githubUsername.toLowerCase(), bugzillaEmail);
+  }
+
+  for (const activity of filteredActivities) {
+    for (const commit of activity.commits) {
+      const username = commit.author;
+      if (!contributors.has(username)) {
+        const bugzillaEmail =
+          reverseEmailMapping.get(username.toLowerCase()) ||
+          Object.entries(emailMapping).find(
+            ([email]) =>
+              email.toLowerCase() === commit.authorEmail.toLowerCase(),
+          )?.[0];
+
+        contributors.set(username, {
+          githubUsername: username,
+          bugzillaEmail,
+          commits: [],
+          pullRequests: [],
+        });
+      }
+      contributors.get(username)!.commits.push(commit);
+    }
+
+    for (const pr of activity.pullRequests) {
+      const username = pr.author;
+      if (!contributors.has(username)) {
+        const bugzillaEmail = reverseEmailMapping.get(username.toLowerCase());
+
+        contributors.set(username, {
+          githubUsername: username,
+          bugzillaEmail,
+          commits: [],
+          pullRequests: [],
+        });
+      }
+      contributors.get(username)!.pullRequests.push(pr);
+    }
+  }
+
+  debugLog?.(
+    `[github] Collected ${activities.length} repos, ${contributors.size} contributors`,
+  );
+
+  return {
+    activity: filteredActivities,
+    contributors,
+    stats: {
+      candidates: { commits: totalCommits, prs: totalPullRequests },
+      qualified: {
+        commits: totalCommits - droppedCommits,
+        prs: totalPullRequests - droppedPullRequests,
+      },
+    },
+  };
+}

--- a/snazzybot/src/status/service.ts
+++ b/snazzybot/src/status/service.ts
@@ -26,8 +26,18 @@ import {
   logWindowStep,
   summarizeOpenAiStep,
 } from "./steps/index.ts";
-import { logWindowContext } from "./recipeHelpers.ts";
+import {
+  logWindowContext,
+  formatSummaryOutput,
+  extractDemoSuggestions,
+} from "./recipeHelpers.ts";
+import { loadPatchContextsForBugs } from "./patchStage.ts";
+import { collectGithubContributors } from "./githubStage.ts";
+import { summarizeWithOpenAI, type SummarizerResult } from "./summarizer.ts";
+import { buildBuglistURL } from "./output.ts";
+import { escapeHtml } from "./markdown.ts";
 import { STEP_PHASE_CONFIG } from "./phases.ts";
+import type { GitHubContributor } from "./githubTypes.ts";
 import type {
   Bug,
   DebugLog,
@@ -391,6 +401,188 @@ export async function qualifyHistoryPage(
     nextCursor,
     total: candidates.length,
     results,
+  };
+}
+
+/**
+ * Summarize one bounded slice of pre-qualified bug ids.
+ *
+ * This is the summarization analogue of {@link qualifyHistoryPage}: instead of
+ * running the entire OpenAI pipeline for every qualified bug in a single
+ * request (which blows Cloudflare's ~100s edge budget and the Free-tier
+ * subrequest cap once a user has many bugs), the client loops over the full
+ * `ids` array in small pages. Each call fetches bug details + patch context for
+ * its slice and runs OpenAI on just that slice, returning a partial summary
+ * fragment. The caller accumulates the fragments and finishes with
+ * {@link assembleSummary}.
+ *
+ * GitHub/Jira context describes the report as a whole, so it is only gathered
+ * and attached on the first chunk (`cursor === 0`) to avoid duplicate sections
+ * and repeated GitHub subrequests.
+ */
+export async function summarizeBugPage(
+  params: GenerateParams,
+  env: EnvLike,
+  ids: number[],
+  cursor: number,
+  pageSize: number,
+  hooks: ProgressHooks = defaultHooks,
+  debug = false,
+): Promise<{
+  summaryFragment: string;
+  assessments: SummarizerResult["assessments"];
+  nextCursor: number | undefined;
+  total: number;
+  githubStats?: StatusStats["github"];
+}> {
+  const normalizedCursor = Number.isFinite(cursor) ? Math.trunc(cursor) : 0;
+  const normalizedPageSize = Math.max(
+    1,
+    Number.isFinite(pageSize) ? Math.trunc(pageSize) : 1,
+  );
+  const start = Math.max(0, normalizedCursor);
+  const end = Math.min(ids.length, start + normalizedPageSize);
+  const idsSlice = ids.slice(start, end);
+  const nextCursor = end < ids.length ? end : undefined;
+
+  if (idsSlice.length === 0) {
+    return {
+      summaryFragment: "",
+      assessments: [],
+      nextCursor: undefined,
+      total: ids.length,
+    };
+  }
+
+  const client = new BugzillaClient(env, hooks);
+  const debugLog = debugLogger(debug, hooks);
+  const days = params.days ?? 8;
+  const sinceISO = isoDaysAgo(days);
+  const model = defaultModel(params.model);
+  const voice = defaultVoice(params.voice);
+  const audience = defaultAudience(ids.length > 0, params.audience);
+  const assignees = (params.assignees ?? [])
+    .map((email) => email?.trim())
+    .filter(Boolean) as string[];
+  const includePatchContext = params.includePatchContext !== false;
+
+  hooks.info?.(
+    `Summarizing pre-qualified bugs ${start + 1}-${end} of ${ids.length}…`,
+  );
+  const bugs = await client.fetchBugsByIds(idsSlice);
+
+  const patchContext = await loadPatchContextsForBugs(env, bugs, hooks, {
+    includePatchContext,
+    debugLog,
+  });
+
+  const isFirstChunk = start === 0;
+  let githubContributors: Map<string, GitHubContributor> | undefined;
+  let githubStats: StatusStats["github"] | undefined;
+  if (isFirstChunk) {
+    const gh = await collectGithubContributors(
+      env,
+      {
+        githubRepos: params.githubRepos ?? [],
+        emailMapping: params.emailMapping ?? {},
+        sinceISO,
+        includeGithubActivity: params.includeGithubActivity === true,
+      },
+      hooks,
+      debugLog,
+    );
+    githubContributors = gh.contributors.size > 0 ? gh.contributors : undefined;
+    githubStats = gh.stats;
+  }
+
+  const result = await summarizeWithOpenAI(
+    env,
+    model,
+    bugs,
+    days,
+    voice,
+    audience,
+    {
+      patchContextByBug: patchContext,
+      groupByAssignee: assignees.length > 0,
+      singleAssignee: assignees.length === 1,
+      githubContributors,
+      jiraIssues: [],
+      hooks,
+    },
+  );
+
+  return {
+    summaryFragment: result.summary_md ?? "",
+    assessments: result.assessments ?? [],
+    nextCursor,
+    total: ids.length,
+    githubStats,
+  };
+}
+
+/**
+ * Assemble the final report from summary fragments accumulated across
+ * {@link summarizeBugPage} calls. Pure formatting — issues no subrequests — so
+ * it always returns well inside Cloudflare's edge budget. Mirrors
+ * `formatOutputStep`.
+ */
+export function assembleSummary(
+  params: GenerateParams,
+  env: EnvLike,
+  ids: number[],
+  summaryFragments: string[],
+  assessments: SummarizerResult["assessments"],
+  trimmedCount: number,
+  candidatesTotal?: number,
+): { output: string; html: string; stats: StatusStats } {
+  const summary_md = (summaryFragments ?? [])
+    .filter((md): md is string => typeof md === "string" && md.length > 0)
+    .join("\n\n");
+  const demo = extractDemoSuggestions(assessments ?? []);
+  const assignees = (params.assignees ?? [])
+    .map((email) => email?.trim())
+    .filter(Boolean) as string[];
+  const link = buildBuglistURL({
+    sinceISO: isoDaysAgo(params.days ?? 8),
+    whiteboards: params.whiteboards ?? [],
+    ids,
+    components: params.components ?? [],
+    assignees,
+    host: env.BUGZILLA_HOST,
+  });
+
+  const stats: StatusStats = {
+    bugzilla: {
+      candidates: candidatesTotal ?? ids.length,
+      qualified: ids.length,
+    },
+  };
+
+  // Nothing qualified → mirror handleEmptyStep's "no changes" message rather
+  // than emitting a bare buglist link.
+  if (summary_md.length === 0) {
+    const days = params.days ?? 8;
+    const markdownBody = `_No user-impacting changes in the last ${days} days._\n\n[View bugs in Bugzilla](${link})`;
+    const htmlBody = `<p><em>No user-impacting changes in the last ${days} days.</em></p><p><a href="${escapeHtml(link)}">View bugs in Bugzilla</a></p>`;
+    return {
+      output: params.format === "html" ? htmlBody : markdownBody,
+      html: htmlBody,
+      stats,
+    };
+  }
+
+  const { markdown, html } = formatSummaryOutput({
+    summaryMd: summary_md,
+    demo,
+    trimmedCount: trimmedCount ?? 0,
+    link,
+  });
+
+  return {
+    output: params.format === "html" ? html : markdown,
+    html,
+    stats,
   };
 }
 

--- a/snazzybot/src/status/steps/fetchGithubActivityStep.ts
+++ b/snazzybot/src/status/steps/fetchGithubActivityStep.ts
@@ -1,8 +1,6 @@
-import { GitHubClient } from "../githubClient.ts";
+import { collectGithubContributors } from "../githubStage.ts";
 import type { RecipeStep } from "../stateMachine.ts";
 import type { StatusContext, StatusStepName } from "../context.ts";
-import type { GitHubContributor } from "../githubTypes.ts";
-import { filterGithubActivity } from "../qualification.ts";
 
 export const fetchGithubActivityStep: RecipeStep<
   StatusStepName,
@@ -10,128 +8,20 @@ export const fetchGithubActivityStep: RecipeStep<
 > = {
   name: "fetch-github-activity",
   run: async (ctx) => {
-    if (!ctx.params.includeGithubActivity || ctx.githubRepos.length === 0) {
-      ctx.githubActivity = [];
-      ctx.githubContributors = new Map();
-      return;
-    }
-
-    if (!ctx.env.GITHUB_API_KEY) {
-      ctx.hooks.warn?.("GitHub API key not provided; skipping GitHub activity");
-      ctx.githubActivity = [];
-      ctx.githubContributors = new Map();
-      return;
-    }
-
-    const client = new GitHubClient(ctx.env);
-    const activities = [];
-
-    for (const repo of ctx.githubRepos) {
-      try {
-        ctx.hooks.info?.(`Fetching GitHub activity for ${repo}`);
-        const activity = await client.getRepoActivity(repo, ctx.sinceISO);
-        activities.push(activity);
-      } catch (error) {
-        ctx.hooks.warn?.(
-          `Failed to fetch GitHub activity for ${repo}: ${error}`,
-        );
-      }
-    }
-
-    const filteredActivities = [];
-    let droppedCommits = 0;
-    let droppedPullRequests = 0;
-    let totalCommits = 0;
-    let totalPullRequests = 0;
-
-    for (const activity of activities) {
-      totalCommits += activity.commits.length;
-      totalPullRequests += activity.pullRequests.length;
-      const filtered = filterGithubActivity(activity, ctx.sinceISO);
-      filteredActivities.push(filtered.activity);
-      droppedCommits += filtered.droppedCommits;
-      droppedPullRequests += filtered.droppedPullRequests;
-    }
-
-    ctx.hooks.info?.(
-      `GitHub Candidates: ${totalCommits} commit${
-        totalCommits === 1 ? "" : "s"
-      }, ${totalPullRequests} PR${totalPullRequests === 1 ? "" : "s"}`,
-    );
-
-    if (droppedCommits + droppedPullRequests > 0) {
-      ctx.hooks.info?.(
-        `GitHub filters removed: ${droppedCommits} commits, ${droppedPullRequests} PRs`,
-      );
-    }
-
-    ctx.hooks.info?.(
-      `GitHub Qualified (window): ${totalCommits - droppedCommits} commit${
-        totalCommits - droppedCommits === 1 ? "" : "s"
-      }, ${totalPullRequests - droppedPullRequests} PR${
-        totalPullRequests - droppedPullRequests === 1 ? "" : "s"
-      }`,
-    );
-
-    ctx.githubActivity = filteredActivities;
-    ctx.githubStats = {
-      candidates: { commits: totalCommits, prs: totalPullRequests },
-      qualified: {
-        commits: totalCommits - droppedCommits,
-        prs: totalPullRequests - droppedPullRequests,
+    const { activity, contributors, stats } = await collectGithubContributors(
+      ctx.env,
+      {
+        githubRepos: ctx.githubRepos,
+        emailMapping: ctx.emailMapping,
+        sinceISO: ctx.sinceISO,
+        includeGithubActivity: ctx.params.includeGithubActivity === true,
       },
-    };
-
-    const contributors = new Map<string, GitHubContributor>();
-
-    const reverseEmailMapping = new Map<string, string>();
-    for (const [bugzillaEmail, githubUsername] of Object.entries(
-      ctx.emailMapping,
-    )) {
-      reverseEmailMapping.set(githubUsername.toLowerCase(), bugzillaEmail);
-    }
-
-    for (const activity of filteredActivities) {
-      for (const commit of activity.commits) {
-        const username = commit.author;
-        if (!contributors.has(username)) {
-          const bugzillaEmail =
-            reverseEmailMapping.get(username.toLowerCase()) ||
-            Object.entries(ctx.emailMapping).find(
-              ([email]) =>
-                email.toLowerCase() === commit.authorEmail.toLowerCase(),
-            )?.[0];
-
-          contributors.set(username, {
-            githubUsername: username,
-            bugzillaEmail,
-            commits: [],
-            pullRequests: [],
-          });
-        }
-        contributors.get(username)!.commits.push(commit);
-      }
-
-      for (const pr of activity.pullRequests) {
-        const username = pr.author;
-        if (!contributors.has(username)) {
-          const bugzillaEmail = reverseEmailMapping.get(username.toLowerCase());
-
-          contributors.set(username, {
-            githubUsername: username,
-            bugzillaEmail,
-            commits: [],
-            pullRequests: [],
-          });
-        }
-        contributors.get(username)!.pullRequests.push(pr);
-      }
-    }
-
-    ctx.githubContributors = contributors;
-
-    ctx.debugLog?.(
-      `[github] Collected ${activities.length} repos, ${contributors.size} contributors`,
+      ctx.hooks,
+      ctx.debugLog,
     );
+
+    ctx.githubActivity = activity;
+    ctx.githubContributors = contributors;
+    if (stats) ctx.githubStats = stats;
   },
 };

--- a/snazzybot/tests/e2e/ui.spec.ts
+++ b/snazzybot/tests/e2e/ui.spec.ts
@@ -123,6 +123,22 @@ const setupPagedFixture = async (page: Page, fixture: PagedFixture) => {
       expect(body.pageSize).toBe(next.request.pageSize);
       return respondJson(route, next.response);
     }
+    if (body?.mode === "summarize") {
+      // Fixtures are small (≤ a handful of bugs), so summarize the whole slice
+      // in one chunk. The rendered output comes from the assemble response, so
+      // the fragment content here is immaterial.
+      const ids = Array.isArray(body.ids) ? body.ids : [];
+      return respondJson(route, {
+        summaryFragment: "fixture fragment",
+        assessments: [],
+        nextCursor: undefined,
+        total: ids.length,
+        logs: [],
+      });
+    }
+    if (body?.mode === "assemble") {
+      return respondJson(route, fixture.responses.finalize);
+    }
     if (body?.mode === "finalize") {
       return respondJson(route, fixture.responses.finalize);
     }

--- a/snazzybot/tests/integration/app.ui.test.ts
+++ b/snazzybot/tests/integration/app.ui.test.ts
@@ -86,7 +86,16 @@ beforeEach(() => {
           total: 1,
         });
       }
-      if (mode === "finalize" || mode === "oneshot") {
+      if (mode === "summarize") {
+        const ids = Array.isArray(body.ids) ? body.ids : [];
+        return HttpResponse.json({
+          summaryFragment: "Hello",
+          assessments: [],
+          nextCursor: undefined,
+          total: ids.length,
+        });
+      }
+      if (mode === "assemble" || mode === "finalize" || mode === "oneshot") {
         return HttpResponse.json({
           output: "Hello\n\n[View bugs in Bugzilla](https://x)",
         });

--- a/snazzybot/tests/integration/core.generateStatus.test.ts
+++ b/snazzybot/tests/integration/core.generateStatus.test.ts
@@ -229,7 +229,7 @@ describe("core integration (with MSW mocks)", () => {
   });
 
   it("adds trimming note when exceeding MAX_BUGS_FOR_OPENAI", async () => {
-    const ids = Array.from({ length: 65 }, (_, i) => 1000 + i);
+    const ids = Array.from({ length: 205 }, (_, i) => 1000 + i);
     server.resetHandlers();
     server.use(
       http.get("https://bugzilla.mozilla.org/rest/bug", ({ request }) => {
@@ -292,7 +292,7 @@ describe("core integration (with MSW mocks)", () => {
       env,
     );
     expect(res.output).toMatch(/omitted from the AI summary/);
-    expect(res.ids.length).toBe(65);
+    expect(res.ids.length).toBe(205);
   });
 
   it("collects bugs by assignee email addresses", async () => {

--- a/snazzybot/tests/integration/functions.status.test.ts
+++ b/snazzybot/tests/integration/functions.status.test.ts
@@ -87,6 +87,67 @@ describe("functions/api/status.ts", () => {
     await mf.dispose();
   });
 
+  it("paging protocol: discover → page → summarize(loop) → assemble", async () => {
+    const mf = await makeMiniflare({}, { forceFallback: true });
+
+    const page = await mf.dispatchFetch("http://local/api/status", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "page",
+        cursor: 0,
+        pageSize: 35,
+        days: 8,
+        whiteboards: ["[fx-vpn]"],
+      }),
+    });
+    const p = await page.json();
+    expect(p.qualifiedIds.length).toBeGreaterThan(0);
+
+    // Loop summarize until nextCursor is undefined, accumulating fragments.
+    const summaryFragments: string[] = [];
+    const assessments: unknown[] = [];
+    let cursor: number | undefined = 0;
+    let guard = 0;
+    while (cursor !== undefined && guard++ < 50) {
+      const chunk = await mf.dispatchFetch("http://local/api/status", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          mode: "summarize",
+          ids: p.qualifiedIds,
+          cursor,
+          pageSize: 8,
+          days: 8,
+          whiteboards: ["[fx-vpn]"],
+        }),
+      });
+      const c = await chunk.json();
+      if (c.summaryFragment) summaryFragments.push(c.summaryFragment);
+      for (const a of c.assessments || []) assessments.push(a);
+      cursor = c.nextCursor;
+    }
+    expect(summaryFragments.length).toBeGreaterThan(0);
+
+    const assemble = await mf.dispatchFetch("http://local/api/status", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "assemble",
+        ids: p.qualifiedIds,
+        summaryFragments,
+        assessments,
+        trimmedCount: 0,
+        candidatesTotal: p.qualifiedIds.length,
+        format: "md",
+        whiteboards: ["[fx-vpn]"],
+      }),
+    });
+    const a = await assemble.json();
+    expect(a.output).toMatch(/View bugs in Bugzilla/);
+    await mf.dispose();
+  });
+
   describe("non-streaming logs (debug=no Run Log support)", () => {
     it("oneshot response includes server hook events as logs[]", async () => {
       const mf = await makeMiniflare({}, { forceFallback: true });
@@ -144,6 +205,47 @@ describe("functions/api/status.ts", () => {
       });
       const j = await r.json();
       expect(Array.isArray(j.logs)).toBe(true);
+      await mf.dispose();
+    });
+
+    it("summarize response includes logs[] and a fragment", async () => {
+      const mf = await makeMiniflare({}, { forceFallback: true });
+      const r = await mf.dispatchFetch("http://local/api/status", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          mode: "summarize",
+          ids: [1_987_802],
+          cursor: 0,
+          pageSize: 8,
+          whiteboards: ["[fx-vpn]"],
+        }),
+      });
+      const j = await r.json();
+      expect(Array.isArray(j.logs)).toBe(true);
+      expect(j.total).toBe(1);
+      expect(j.nextCursor).toBeUndefined();
+      expect(typeof j.summaryFragment).toBe("string");
+      await mf.dispose();
+    });
+
+    it("assemble response includes logs[] and output", async () => {
+      const mf = await makeMiniflare({}, { forceFallback: true });
+      const r = await mf.dispatchFetch("http://local/api/status", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          mode: "assemble",
+          ids: [1_987_802],
+          summaryFragments: ["A summary fragment."],
+          assessments: [],
+          format: "md",
+          whiteboards: ["[fx-vpn]"],
+        }),
+      });
+      const j = await r.json();
+      expect(Array.isArray(j.logs)).toBe(true);
+      expect(j.output).toMatch(/View bugs in Bugzilla/);
       await mf.dispose();
     });
 
@@ -434,22 +536,26 @@ describe("functions/api/status.ts", () => {
       },
     );
 
-    it.each(["discover", "page", "finalize", "oneshot"])(
-      "accepts valid mode value: %s",
-      async (mode) => {
-        const mf = await makeMiniflare({}, { forceFallback: true });
-        const r = await mf.dispatchFetch("http://local/api/status", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            mode,
-            whiteboards: ["[fx-vpn]"],
-          }),
-        });
-        expect(r.status).not.toBe(400);
-        await mf.dispose();
-      },
-    );
+    it.each([
+      "discover",
+      "page",
+      "summarize",
+      "assemble",
+      "finalize",
+      "oneshot",
+    ])("accepts valid mode value: %s", async (mode) => {
+      const mf = await makeMiniflare({}, { forceFallback: true });
+      const r = await mf.dispatchFetch("http://local/api/status", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          mode,
+          whiteboards: ["[fx-vpn]"],
+        }),
+      });
+      expect(r.status).not.toBe(400);
+      await mf.dispose();
+    });
 
     it("accepts valid input within limits", async () => {
       const mf = await makeMiniflare({}, { forceFallback: true });

--- a/snazzybot/tests/unit/service.assembleSummary.test.ts
+++ b/snazzybot/tests/unit/service.assembleSummary.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { assembleSummary } from "../../src/core.ts";
+
+const env = {
+  OPENAI_API_KEY: "test-openai",
+  BUGZILLA_API_KEY: "test-bz",
+};
+
+describe("assembleSummary", () => {
+  it("joins fragments with blank lines and appends the buglist link (md + html)", () => {
+    const { output, html } = assembleSummary(
+      { days: 8, format: "md", assignees: ["dev@example.com"] },
+      env,
+      [101, 102],
+      ["First fragment.", "Second fragment."],
+      [],
+      0,
+    );
+    expect(output).toContain("First fragment.");
+    expect(output).toContain("Second fragment.");
+    // joined with a blank line between fragments
+    expect(output).toContain("First fragment.\n\nSecond fragment.");
+    expect(output).toMatch(/\[View bugs in Bugzilla\]\(/);
+    expect(html).toMatch(/View bugs in Bugzilla/);
+    expect(html).toContain("<a href=");
+  });
+
+  it("drops empty fragments before joining", () => {
+    const { output } = assembleSummary(
+      { days: 8, format: "md" },
+      env,
+      [1],
+      ["", "Only real fragment.", ""],
+      [],
+      0,
+    );
+    expect(output).toContain("Only real fragment.");
+    expect(output).not.toMatch(/\n\n\n/);
+  });
+
+  it("includes demo suggestions only for assessments scoring >= 8 with a suggestion", () => {
+    const { output } = assembleSummary(
+      { days: 8, format: "md" },
+      env,
+      [1, 2, 3],
+      ["Body."],
+      [
+        { bug_id: 1, impact_score: 9, demo_suggestion: "Demo the new toggle." },
+        { bug_id: 2, impact_score: 7, demo_suggestion: "Too low to show." },
+        { bug_id: 3, impact_score: 10, demo_suggestion: undefined },
+      ],
+      0,
+    );
+    expect(output).toContain("Demo suggestions");
+    expect(output).toContain("Demo the new toggle.");
+    expect(output).not.toContain("Too low to show.");
+  });
+
+  it("renders the trimmed-count note when trimmedCount > 0", () => {
+    const { output } = assembleSummary(
+      { days: 8, format: "md" },
+      env,
+      [1],
+      ["Body."],
+      [],
+      3,
+    );
+    expect(output).toMatch(
+      /3 additional bugs were omitted from the AI summary/,
+    );
+  });
+
+  it("returns html as output when format is html", () => {
+    const { output, html } = assembleSummary(
+      { days: 8, format: "html" },
+      env,
+      [1],
+      ["Body."],
+      [],
+      0,
+    );
+    expect(output).toBe(html);
+  });
+
+  it("renders the no-changes message when there are no fragments", () => {
+    const { output, html } = assembleSummary(
+      { days: 8, format: "md" },
+      env,
+      [],
+      [],
+      [],
+      0,
+    );
+    expect(output).toMatch(/No user-impacting changes in the last 8 days/);
+    expect(output).toMatch(/View bugs in Bugzilla/);
+    expect(html).toContain("<em>No user-impacting changes");
+  });
+
+  it("reports candidatesTotal and qualified counts in stats", () => {
+    const { stats } = assembleSummary(
+      { days: 8, format: "md" },
+      env,
+      [1, 2, 3],
+      ["Body."],
+      [],
+      0,
+      96,
+    );
+    expect(stats.bugzilla?.candidates).toBe(96);
+    expect(stats.bugzilla?.qualified).toBe(3);
+  });
+});

--- a/snazzybot/tests/unit/service.summarizeBugPage.test.ts
+++ b/snazzybot/tests/unit/service.summarizeBugPage.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../utils/msw/node";
+import { summarizeBugPage } from "../../src/core.ts";
+
+const env = {
+  OPENAI_API_KEY: "test-openai",
+  BUGZILLA_API_KEY: "test-bz",
+  SNAZZY_SKIP_CACHE: true,
+};
+
+// Echo the requested ids back as bugs so slicing is observable.
+const echoBugsHandler = () =>
+  http.get("https://bugzilla.mozilla.org/rest/bug", ({ request }) => {
+    const url = new URL(request.url);
+    const idsParam = url.searchParams.get("id");
+    if (!idsParam) return HttpResponse.json({ bugs: [] });
+    const requested = idsParam.split(",").map(Number);
+    return HttpResponse.json({
+      bugs: requested.map((id) => ({
+        id,
+        summary: `bug-${id}`,
+        product: "Firefox",
+        component: "General",
+        status: "RESOLVED",
+        resolution: "FIXED",
+        last_change_time: "2025-10-21T09:36:11Z",
+        groups: [],
+        depends_on: [],
+        blocks: [],
+        assigned_to: "dev@example.com",
+      })),
+    });
+  });
+
+describe("summarizeBugPage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date("2025-10-29T09:36:11Z") });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("only summarizes the requested slice and reports the next cursor", async () => {
+    const requestedIdParams: string[] = [];
+    server.use(
+      http.get("https://bugzilla.mozilla.org/rest/bug", ({ request }) => {
+        const url = new URL(request.url);
+        const idsParam = url.searchParams.get("id");
+        if (idsParam) requestedIdParams.push(idsParam);
+        if (!idsParam) return HttpResponse.json({ bugs: [] });
+        const requested = idsParam.split(",").map(Number);
+        return HttpResponse.json({
+          bugs: requested.map((id) => ({
+            id,
+            summary: `bug-${id}`,
+            product: "Firefox",
+            component: "General",
+            status: "RESOLVED",
+            resolution: "FIXED",
+            last_change_time: "2025-10-21T09:36:11Z",
+            groups: [],
+            depends_on: [],
+            blocks: [],
+            assigned_to: "dev@example.com",
+          })),
+        });
+      }),
+    );
+
+    const ids = [1, 2, 3, 4, 5];
+    const page = await summarizeBugPage(
+      { days: 8, includePatchContext: false },
+      env,
+      ids,
+      0,
+      2,
+    );
+
+    expect(page.total).toBe(5);
+    expect(page.nextCursor).toBe(2);
+    expect(typeof page.summaryFragment).toBe("string");
+    expect(Array.isArray(page.assessments)).toBe(true);
+    // Only the first two ids were fetched/summarized.
+    expect(requestedIdParams.join("|")).toContain("1,2");
+    expect(requestedIdParams.join("|")).not.toContain("3");
+  });
+
+  it("returns undefined nextCursor for the final slice", async () => {
+    server.use(echoBugsHandler());
+    const ids = [10, 11, 12];
+    const page = await summarizeBugPage(
+      { days: 8, includePatchContext: false },
+      env,
+      ids,
+      2,
+      2,
+    );
+    expect(page.nextCursor).toBeUndefined();
+    expect(page.total).toBe(3);
+  });
+
+  it("fetches GitHub activity only on the first chunk (cursor === 0)", async () => {
+    let githubCommitCalls = 0;
+    server.use(
+      echoBugsHandler(),
+      http.get("https://api.github.com/repos/:owner/:repo/commits", () => {
+        githubCommitCalls += 1;
+        return HttpResponse.json([]);
+      }),
+      http.get("https://api.github.com/repos/:owner/:repo/pulls", () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    const params = {
+      days: 8,
+      includePatchContext: false,
+      includeGithubActivity: true,
+      githubRepos: ["mozilla/example"],
+    };
+    const envWithGithub = { ...env, GITHUB_API_KEY: "gh-token" };
+    const ids = [1, 2, 3, 4];
+
+    await summarizeBugPage(params, envWithGithub, ids, 0, 2);
+    expect(githubCommitCalls).toBe(1);
+
+    // A later chunk must not re-fetch GitHub activity.
+    await summarizeBugPage(params, envWithGithub, ids, 2, 2);
+    expect(githubCommitCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
The paged web flow ended with a single finalize request that ran the entire pipeline (patch context + every OpenAI batch) for all qualified bugs at once. With many bugs (e.g. 96 from an assignee search, capped to 60) this exceeded Cloudflare's ~100s edge budget and the Free-tier 50-subrequest cap, returning a 524.

Split summarization into bounded HTTP requests, mirroring discover/page:

- summarizeBugPage: summarize one slice of ids (details + patch context + OpenAI for <=8 bugs) and return a partial fragment + nextCursor. GitHub/Jira context is attached only on the first chunk (cursor 0).
- assembleSummary: pure formatting (no subrequests) that joins fragments, builds demo suggestions + buglist link, and preserves the empty-result message.
- Add summarize/assemble worker modes with validation.
- runSnazzyPaged loops summarize in chunks of 8 (driving the determinate openai progress bar over all qualified bugs) then calls assemble, so no bugs are silently dropped.
- Extract collectGithubContributors into githubStage.ts so GitHub activity is fetched exactly once.
- Raise MAX_BUGS_FOR_OPENAI 60 -> 200 (now only a guardrail for the legacy/streaming/CLI paths).

finalize/oneshot/streaming/CLI paths are unchanged. Adds unit + integration coverage for the new functions and modes.